### PR TITLE
BaSP-TG-102: Change input name from passwword to password

### DIFF
--- a/src/Components/SuperAdmins/Form/index.js
+++ b/src/Components/SuperAdmins/Form/index.js
@@ -161,7 +161,7 @@ const Form = () => {
       <div className={styles.inputDiv}>
         <InputField
           label="Password"
-          name="passwword"
+          name="password"
           type="password"
           placeholder="password"
           value={superAdmin.password}


### PR DESCRIPTION
In Components/SuperAdmins/Form/index.js
Line 164:

Error on prop "name". Is written as "passwword". Should be "password"

FIXED